### PR TITLE
Clean clone cannot build. Missing bitcoinj repository URL.

### DIFF
--- a/wallet/pom.xml
+++ b/wallet/pom.xml
@@ -15,6 +15,13 @@
 		<version>1</version>
 	</parent>
 
+    <repositories>
+        <repository>
+            <id>bitcoinj</id>
+            <url>http://distribution.bitcoinj.googlecode.com/git/releases/</url>
+        </repository>
+    </repositories>
+
 	<dependencies>
 
 		<!-- android.*, java.*, javax.* -->


### PR DESCRIPTION
I tried to build from a clean clone. But Maven could not resolve the bitcoinj dependency due to its missing repository URL.

Attaching a pull request.
