### PR TITLE
Fix constant name typo.

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/InputParser.java
+++ b/wallet/src/de/schildbach/wallet/ui/InputParser.java
@@ -75,7 +75,7 @@ public abstract class InputParser
 				}
 				catch (final BitcoinURIParseException x)
 				{
-					error(R.string.input_parser_invalid_litecoin_uri, input);
+					error(R.string.input_parser_invalid_Litecoin_uri, input);
 				}
 			}
 			else if (PATTERN_BITCOIN_ADDRESS.matcher(input).matches())


### PR DESCRIPTION
The string resource constant referred to in `InputParser.java`:

```
    error(R.string.input_parser_invalid_litecoin_uri, input);
```

seems to be a typo, as there is no such string resource. There is, however:

```
<string name="input_parser_invalid_Litecoin_uri">Invalid Litecoin URI:\n%s</string
```

Note the `_litecoin_` -- `_Litecoin_` typo.
