### PR TITLE
Add a "Disconnect" action on the ongoing peer connectivity notification (4.1+ only).

### DIFF
--- a/wallet/pom.xml
+++ b/wallet/pom.xml
@@ -35,11 +35,13 @@
 		</dependency>
 
 		<!-- android.support.v4.* -->
+        <!-- Maven central does not have the latest version (v13)! In fact, it's not even official!
 		<dependency>
 			<groupId>com.google.android</groupId>
 			<artifactId>support-v4</artifactId>
 			<version>r7</version>
 		</dependency>
+		-->
 
 		<!-- com.actionbarsherlock.* -->
 		<dependency>

--- a/wallet/src/de/schildbach/wallet/service/BlockchainService.java
+++ b/wallet/src/de/schildbach/wallet/service/BlockchainService.java
@@ -47,6 +47,7 @@ public interface BlockchainService
 	public static final String ACTION_RESET_BLOCKCHAIN = R.class.getPackage().getName() + ".reset_blockchain";
 	public static final String ACTION_BROADCAST_TRANSACTION = R.class.getPackage().getName() + ".broadcast_transaction";
 	public static final String ACTION_BROADCAST_TRANSACTION_HASH = "hash";
+    public static final String ACTION_STOP_SERVICE = "stop_service";
 
 	@CheckForNull
 	List<Peer> getConnectedPeers();

--- a/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.java
+++ b/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.java
@@ -292,9 +292,6 @@ public class BlockchainServiceImpl extends android.app.Service implements Blockc
                                 .setWhen(System.currentTimeMillis())
                                 .setOngoing(true)
                                 /*
-                                 * Sets the big view "big text" style and supplies the
-                                 * text (the user's reminder message) that will be displayed
-                                 * in the detail area of the expanded notification.
                                  * These calls are ignored by the support library for
                                  * pre-4.1 devices.
                                  */

--- a/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.java
+++ b/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.java
@@ -727,6 +727,7 @@ public class BlockchainServiceImpl extends android.app.Service implements Blockc
         else if (BlockchainService.ACTION_STOP_SERVICE.equals(action))
         {
             log.info("stopping self");
+            // deliberate stop command, so don't schedule restart
             stopSelf();
         }
 

--- a/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.java
+++ b/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.java
@@ -560,6 +560,7 @@ public class BlockchainServiceImpl extends android.app.Service implements Blockc
 				if (isIdle)
 				{
 					log.info("idling detected, stopping service");
+                    WalletApplication.scheduleStartBlockchainService(BlockchainServiceImpl.this);
 					stopSelf();
 				}
 			}
@@ -705,6 +706,7 @@ public class BlockchainServiceImpl extends android.app.Service implements Blockc
 			log.info("will remove blockchain on service shutdown");
 
 			resetBlockchainOnShutdown = true;
+            WalletApplication.scheduleStartBlockchainService(this);
 			stopSelf();
 		}
 		else if (BlockchainService.ACTION_BROADCAST_TRANSACTION.equals(action))
@@ -735,8 +737,6 @@ public class BlockchainServiceImpl extends android.app.Service implements Blockc
 	public void onDestroy()
 	{
 		log.debug(".onDestroy()");
-
-		WalletApplication.scheduleStartBlockchainService(this);
 
 		unregisterReceiver(tickReceiver);
 
@@ -794,6 +794,7 @@ public class BlockchainServiceImpl extends android.app.Service implements Blockc
 	public void onLowMemory()
 	{
 		log.warn("low memory detected, stopping service");
+        WalletApplication.scheduleStartBlockchainService(this);
 		stopSelf();
 	}
 

--- a/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.java
+++ b/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.java
@@ -234,7 +234,7 @@ public class BlockchainServiceImpl extends android.app.Service implements Blockc
 		notification.setNumber(notificationCount == 1 ? 0 : notificationCount);
 		notification.setWhen(System.currentTimeMillis());
 		notification.setSound(Uri.parse("android.resource://" + getPackageName() + "/" + R.raw.coins_received));
-		nm.notify(NOTIFICATION_ID_COINS_RECEIVED, notification.getNotification());
+		nm.notify(NOTIFICATION_ID_COINS_RECEIVED, notification.build());
 	}
 
 
@@ -277,30 +277,34 @@ public class BlockchainServiceImpl extends android.app.Service implements Blockc
 				@Override
 				public void run()
 				{
-
-                    final NotificationCompat.Builder notification = new NotificationCompat.Builder(BlockchainServiceImpl.this)
-                            .setSmallIcon(R.drawable.stat_sys_peers, numPeers > 4 ? 4 : numPeers)
-                            .setContentTitle(getString(R.string.app_name))
-                            .setContentText(getString(R.string.notification_peers_connected_msg, numPeers))
-                            .setContentIntent(PendingIntent.getActivity(BlockchainServiceImpl.this, 0, new Intent(BlockchainServiceImpl.this,
-                                    WalletActivity.class), 0))
-                            .setWhen(System.currentTimeMillis())
-                            .setOngoing(true)
-                            /*
-                             * Sets the big view "big text" style and supplies the
-                             * text (the user's reminder message) that will be displayed
-                             * in the detail area of the expanded notification.
-                             * These calls are ignored by the support library for
-                             * pre-4.1 devices.
-                             */
-                            .setStyle(new NotificationCompat.BigTextStyle()
-                                    .bigText(getString(R.string.notification_peers_connected_msg, numPeers)))
-                            .addAction(R.drawable.stat_sys_peers_0,     // TODO: replace with a disconnect icon
-                                    getString(R.string.wallet_options_disconnect),
-                                    PendingIntent.getService(BlockchainServiceImpl.this, 0,
-                                            new Intent(BlockchainServiceImpl.this, BlockchainServiceImpl.class)
-                                            .setAction(BlockchainService.ACTION_STOP_SERVICE), 0));
-                    nm.notify(NOTIFICATION_ID_CONNECTED, notification.build());
+                    if (numPeers == 0)
+                    {
+                        nm.cancel(NOTIFICATION_ID_CONNECTED);
+                    }
+                    else
+                    {
+                        final NotificationCompat.Builder notification = new NotificationCompat.Builder(BlockchainServiceImpl.this)
+                                .setSmallIcon(R.drawable.stat_sys_peers, numPeers > 4 ? 4 : numPeers)
+                                .setContentTitle(getString(R.string.app_name))
+                                .setContentText(getString(R.string.notification_peers_connected_msg, numPeers))
+                                .setContentIntent(PendingIntent.getActivity(BlockchainServiceImpl.this, 0, new Intent(BlockchainServiceImpl.this,
+                                        WalletActivity.class), 0))
+                                .setWhen(System.currentTimeMillis())
+                                .setOngoing(true)
+                                /*
+                                 * Sets the big view "big text" style and supplies the
+                                 * text (the user's reminder message) that will be displayed
+                                 * in the detail area of the expanded notification.
+                                 * These calls are ignored by the support library for
+                                 * pre-4.1 devices.
+                                 */
+                                .addAction(R.drawable.ic_action_clear,
+                                        getString(R.string.wallet_options_disconnect),
+                                        PendingIntent.getService(BlockchainServiceImpl.this, 0,
+                                                new Intent(BlockchainServiceImpl.this, BlockchainServiceImpl.class)
+                                                        .setAction(BlockchainService.ACTION_STOP_SERVICE), 0));
+                        nm.notify(NOTIFICATION_ID_CONNECTED, notification.build());
+                    }
 
 					// send broadcast
 					sendBroadcastPeerState(numPeers);
@@ -400,8 +404,6 @@ public class BlockchainServiceImpl extends android.app.Service implements Blockc
 				peerGroup.addWallet(wallet);
 				peerGroup.setUserAgent(Constants.USER_AGENT, application.packageInfo().versionName);
 				peerGroup.addEventListener(peerConnectivityListener);
-
-                peerConnectivityListener.changed(0);    // initialize it with 0 to kick off sticky notification
 
 				final int maxConnectedPeers = application.maxConnectedPeers();
 

--- a/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.java
+++ b/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.java
@@ -284,15 +284,15 @@ public class BlockchainServiceImpl extends android.app.Service implements Blockc
 					}
 					else
 					{
-						final NotificationCompat.Builder notification = new NotificationCompat.Builder(BlockchainServiceImpl.this);
-						notification.setSmallIcon(R.drawable.stat_sys_peers, numPeers > 4 ? 4 : numPeers);
-						notification.setContentTitle(getString(R.string.app_name));
-						notification.setContentText(getString(R.string.notification_peers_connected_msg, numPeers));
-						notification.setContentIntent(PendingIntent.getActivity(BlockchainServiceImpl.this, 0, new Intent(BlockchainServiceImpl.this,
-								WalletActivity.class), 0));
-						notification.setWhen(System.currentTimeMillis());
-						notification.setOngoing(true);
-						nm.notify(NOTIFICATION_ID_CONNECTED, notification.getNotification());
+						final NotificationCompat.Builder notification = new NotificationCompat.Builder(BlockchainServiceImpl.this)
+                                .setSmallIcon(R.drawable.stat_sys_peers, numPeers > 4 ? 4 : numPeers)
+						        .setContentTitle(getString(R.string.app_name))
+						        .setContentText(getString(R.string.notification_peers_connected_msg, numPeers))
+						        .setContentIntent(PendingIntent.getActivity(BlockchainServiceImpl.this, 0, new Intent(BlockchainServiceImpl.this,
+                                        WalletActivity.class), 0))
+						        .setWhen(System.currentTimeMillis())
+						        .setOngoing(true);
+						nm.notify(NOTIFICATION_ID_CONNECTED, notification.build());
 					}
 
 					// send broadcast


### PR DESCRIPTION
Utilize additional action (button) that can be attached to the peer connectivity notification to disconnect (4.1+ only). Currently, to disconnect from the network, the user has to launch the application's main activity first and then tap the "Disconnect" menu item from the overflow. Using an action button on the notification itself is much more efficient.

Looks like this:

![screenshot_2014-01-28-13-38-55](https://f.cloud.github.com/assets/152710/2024113/47c4a94a-8865-11e3-9df0-5e602ecd35aa.png)

However, this requires android-v4 support library r11+, whereas the current maven configuration pulls from support library r7. I had to comment that out and replace the support library manually (r13 is bundled with the Android SDK). I don't see any maven central repository for this, actually (seems like the ones that are there are not official to begin with).
